### PR TITLE
Don't add redundant ALLOWED_HOSTS entries

### DIFF
--- a/fab_deploy2/default-configs/templates/base/django/base_settings
+++ b/fab_deploy2/default-configs/templates/base/django/base_settings
@@ -5,9 +5,9 @@ MEDIA_ROOT = '{{ nginx.uploads_location }}/'
 ALLOWED_HOSTS = [
     {% for h in nginx.hosts %}
         {% if h.startswith('*.') %}
-        '{{ h[1:] }}', '{{ h[1:] }}.',
+        '{{ h[1:] }}',
         {% else %}
-        '{{ h }}', '{{ h }}.',
+        '{{ h }}',
         {% endif %}
     {% endfor %}
 ]


### PR DESCRIPTION
Per [Django docs](https://docs.djangoproject.com/en/1.7/ref/settings/#allowed-hosts), as of Django 1.7 trailing dots are stripped and the duplicate entries here are therefore redundant. 