### PR TITLE
Making gunicorn log level configurable

### DIFF
--- a/fab_deploy2/base/gunicorn.py
+++ b/fab_deploy2/base/gunicorn.py
@@ -33,6 +33,7 @@ class Gunicorn(ServiceContextTask):
         'daemonize' : True,
         'project_path' : '/project/',
         'conf_location' : '',
+        'log_level': 'WARNING',
     }
 
     def _setup_service(self):

--- a/fab_deploy2/default-configs/templates/base/gunicorn/gunicorn.pt
+++ b/fab_deploy2/default-configs/templates/base/gunicorn/gunicorn.pt
@@ -6,7 +6,7 @@ bind = "{{ gunicorn.listen_address }}"
 # Make sure to tune
 workers = {{ gunicorn.num_workers }}
 
-loglevel = "WARNING"
+loglevel = "{{ gunicorn.log_level }}"
 logfile = "{{ gunicorn.log_file }}"
 django_settings = "settings"
 {% endblock %}


### PR DESCRIPTION
Currently, *log_level* for *gunicorn* is set to *WARNING* by default and it cannot be changed using a variable context. This new code chunk allows us to do that.