### PR TITLE
Using 444 instead of redirection for not allowed hosts

### DIFF
--- a/fab_deploy2/default-configs/templates/base/nginx/nginx.conf
+++ b/fab_deploy2/default-configs/templates/base/nginx/nginx.conf
@@ -178,27 +178,16 @@ http {
         {% endblock %}
     }
 
-    {% block redirect_server %}
     {% if nginx.hosts %}
     server {
-        listen {{ nginx.listen }} default_server;
-        server_name _;
+      listen {{ nginx.listen }} default_server;
+      server_name _;
 
-        {% if nginx.status %}
-        location /nginx_status {
-            stub_status on;
-            access_log   off;
-            allow 127.0.0.1;
-            deny all;
-        }
-        {% endif %}
-
-        location / {
-            allow all;
-            return 301 $scheme://{{ nginx.hosts[0] }}$request_uri;
-        }
+      return 444;
     }
     {% endif %}
+
+    {% block redirect_server %}
     {% endblock %}
 
     {% endblock %}


### PR DESCRIPTION
Using 444 instead of redirection for not allowed hosts
